### PR TITLE
Fixed bug with rejection on ios

### DIFF
--- a/ios/RNPaystack.m
+++ b/ios/RNPaystack.m
@@ -130,7 +130,7 @@ RCT_EXPORT_METHOD(chargeCard:(NSDictionary *)params
     requestIsCompleted = NO;
     
     if (! [self cardParamsAreValid:params[@"cardNumber"] withMonth:params[@"expiryMonth"] withYear:params[@"expiryYear"] andWithCvc:params[@"cvc"]]) {
-
+        requestIsCompleted = YES;
         // NSMutableDictionary *returnInfo = [self setErrorMsg:self.errorMsg withErrorCode:self.errorCode];
         if (_reject) {
             _reject(self.errorCode, self.errorMsg, nil);
@@ -224,7 +224,7 @@ RCT_EXPORT_METHOD(chargeCardWithAccessCode:(NSDictionary *)params
     requestIsCompleted = NO;
     
     if (! [self cardParamsAreValid:params[@"cardNumber"] withMonth:params[@"expiryMonth"] withYear:params[@"expiryYear"] andWithCvc:params[@"cvc"]]) {
-
+        requestIsCompleted = YES;
         // NSMutableDictionary *returnInfo = [self setErrorMsg:self.errorMsg withErrorCode:self.errorCode];
         if (_reject) {
             _reject(self.errorCode, self.errorMsg, nil);


### PR DESCRIPTION
Hello @tolu360 , good job with this project!

There is a bug around `cardParamsAreValid`  block when a charge is attempted with invalid card details, and expected error is thrown, subsequent trials always return `Another request is still being processed, please wait`.  It is caused because `requestIsCompleted` was not updated when the initial error was thrown; this PR fixes that.

This may in part fix https://github.com/tolu360/react-native-paystack/issues/38#issuecomment-541995184

Cheers! :)