### PR TITLE
fixed pinpad 1.0.1 causing build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
     implementation 'com.squareup.retrofit2:retrofit:2.5.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.5.0'
-    implementation 'co.paystack.android.design.widget:pinpad:1.0.1'
+    implementation 'co.paystack.android.design.widget:pinpad:1.0.3'
     implementation 'co.paystack.android:paystack:3.0.12'   
 }


### PR DESCRIPTION
Hi @tolu360 , i have spent quite sometime now fixing this package from my node_modules, the error is on android specifically for my use case and my react-native version is 0.64